### PR TITLE
유저 역할별 가게 전체, 단건 조회 조건 수정

### DIFF
--- a/src/main/java/com/example/outsourcingproject/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/outsourcingproject/common/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     EXCEED_STORE_LIMIT("최대 3개 까지의 가게를 등록할 수 있습니다.",HttpStatus.BAD_REQUEST),
     STORE_NOT_FOUND("가게 정보를 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
     UNAUTHORIZED_STORE_ACCESS("본인의 가게가 아닙니다.",HttpStatus.BAD_REQUEST),
+    CANNOT_MODIFY_DELETED_STORE("폐업한 가게는 영업이 불가능합니다.",HttpStatus.BAD_REQUEST),
     //메뉴 관련 에러 코드
     NOT_FOUND_MENU("메뉴가 없습니다.", HttpStatus.NOT_FOUND),
     //주문 관련 에러 코드

--- a/src/main/java/com/example/outsourcingproject/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/outsourcingproject/domain/order/service/OrderService.java
@@ -180,7 +180,7 @@ public class OrderService {
                 Menu findMenu = menuRepository.findByIdOrElseThrow(findOrderItem.getMenu().getId());
 
                 MenuResponseDto menuResponseDto = new MenuResponseDto(
-                        findMenu.getName(),
+                        findMenu.getMenuName(),
                         formatter.format(findMenu.getPrice()),
                         findOrderItem.getCount()
                 );
@@ -194,9 +194,9 @@ public class OrderService {
             Store findStore = storeRepository.findByIdOrElseThrow(findOrder.getStore().getId());
 
             UserOrdersResponseDto dto = new UserOrdersResponseDto(
-                    findStore.getName(),
+                    findStore.getStoreName(),
                     menuResponseDtoList,
-                    findStore.getCategory(),
+                    findStore.getCategory().name(),
                     findOrder.getStatus(),
                     formatter.format(totalPrice)
             );

--- a/src/main/java/com/example/outsourcingproject/domain/store/controller/StoreOwnerController.java
+++ b/src/main/java/com/example/outsourcingproject/domain/store/controller/StoreOwnerController.java
@@ -6,10 +6,9 @@ import com.example.outsourcingproject.domain.store.dto.request.StoreCreateReques
 import com.example.outsourcingproject.domain.store.dto.request.StoreDeleteRequestDto;
 import com.example.outsourcingproject.domain.store.dto.request.StoreUpdateRequestDto;
 import com.example.outsourcingproject.domain.store.dto.response.StoreResponseDto;
-import com.example.outsourcingproject.domain.store.service.StoreService;
+import com.example.outsourcingproject.domain.store.service.StoreOwnerService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,39 +16,39 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/v1/stores")
+@RequestMapping("/api/v1/owner/stores")
 @RequiredArgsConstructor
-public class StoreController {
-    private final StoreService storeService;
+public class StoreOwnerController {
+    private final StoreOwnerService storeOwnerService;
 
     @PostMapping
     public ResponseEntity<String>createStore(
             @Auth AuthUser authUser,
             @Valid @RequestBody StoreCreateRequestDto dto
     ){
-        storeService.createStore(authUser.getId(),dto);
+        storeOwnerService.createStore(authUser.getId(),dto);
         return new ResponseEntity<>("가게 등록에 성공 했습니다.", HttpStatus.CREATED);
     }
 
     @GetMapping
-    public List<StoreResponseDto> getAllStores(){
-      return storeService.getAllStores();
+    public List<StoreResponseDto> getAllStores(@Auth AuthUser authUser){
+      return storeOwnerService.getAllStores(authUser.getId());
     }
 
     @GetMapping("/{storeId}")
     public StoreResponseDto getStoreById(
             @PathVariable Long storeId,
             @Auth AuthUser authUser) {
-        return storeService.getStoreById(authUser.getId(), storeId);
+        return storeOwnerService.getStoreById(storeId, authUser.getId());
     }
 
     @PatchMapping("/{storeId}")
     public ResponseEntity<String>updateStore(
             @Auth AuthUser authUser,
             @PathVariable Long storeId,
-            @RequestBody StoreUpdateRequestDto dto
+            @Valid @RequestBody StoreUpdateRequestDto dto
     ){
-        storeService.updateStore(authUser.getId(), storeId, dto);
+        storeOwnerService.updateStore(authUser.getId(), storeId, dto);
         return new ResponseEntity<>("가게 정보 수정을 성공 했습니다.",HttpStatus.OK);
     }
 
@@ -59,7 +58,7 @@ public class StoreController {
             @PathVariable Long storeId,
             @Valid @RequestBody StoreDeleteRequestDto dto
     ){
-        storeService.deleteStore(authUser.getId(), storeId, dto);
+        storeOwnerService.deleteStore(authUser.getId(), storeId, dto);
         return new ResponseEntity<>("가게를 폐업하였습니다.",HttpStatus.NO_CONTENT);
     }
 
@@ -68,7 +67,7 @@ public class StoreController {
             @Auth AuthUser authUser,
             @PathVariable Long storeId
     ) {
-        String storeStatus = storeService.toggleStoreStatus(authUser.getId(), storeId);
+        String storeStatus = storeOwnerService.toggleStoreStatus(authUser.getId(), storeId);
 
         return new ResponseEntity<>(storeStatus, HttpStatus.OK);
     }

--- a/src/main/java/com/example/outsourcingproject/domain/store/controller/StoreUserController.java
+++ b/src/main/java/com/example/outsourcingproject/domain/store/controller/StoreUserController.java
@@ -1,0 +1,31 @@
+package com.example.outsourcingproject.domain.store.controller;
+
+import com.example.outsourcingproject.common.annotation.Auth;
+import com.example.outsourcingproject.common.dto.AuthUser;
+import com.example.outsourcingproject.domain.store.dto.response.StoreResponseDto;
+import com.example.outsourcingproject.domain.store.service.StoreUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("api/v1/stores")
+@RequiredArgsConstructor
+public class StoreUserController {
+    private final StoreUserService storeUserService;
+
+    @GetMapping
+    public List<StoreResponseDto> getAllStores(){
+        return storeUserService.getAllStores();
+    }
+
+    @GetMapping("/{storeId}")
+    public StoreResponseDto getStoreById(
+            @PathVariable Long storeId) {
+        return storeUserService.getStoreById(storeId);
+    }
+}

--- a/src/main/java/com/example/outsourcingproject/domain/store/dto/request/StoreUpdateRequestDto.java
+++ b/src/main/java/com/example/outsourcingproject/domain/store/dto/request/StoreUpdateRequestDto.java
@@ -1,17 +1,27 @@
 package com.example.outsourcingproject.domain.store.dto.request;
 
 import com.example.outsourcingproject.domain.store.enums.StoreCategory;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.time.LocalTime;
 @Getter
 public class StoreUpdateRequestDto {
-
+    @NotBlank(message = "가게 이름은 필수 입력 값입니다.")
     private String storeName;
+    @NotBlank(message = "가게 주소는 필수 입력 값입니다.")
     private String address;
+    @NotBlank(message = "가게 번호는 필수 입력 값입니다.")
     private String phone;
+    @NotNull(message = "카테고리는 필수 입력 값입니다.")
     private StoreCategory category;
+    @NotNull
+    @Min(value = 5000, message = "최소 주문 금액은 5000원 이상 입니다.")
     private Integer minPrice;
+    @NotNull(message = "오픈시간은 필수 입력 값입니다.")
     private LocalTime openTime;
+    @NotNull(message = "마감시간은 필수 입력 값입니다.")
     private LocalTime closeTime;
 }

--- a/src/main/java/com/example/outsourcingproject/domain/store/entity/Store.java
+++ b/src/main/java/com/example/outsourcingproject/domain/store/entity/Store.java
@@ -57,8 +57,12 @@ public class Store extends BaseEntity {
     @JoinColumn(name = "user_id",nullable = false)
     private User user;
 
-    public void updateStore(String storeName, String address, String phone, StoreCategory category,
-                     Integer minPrice, LocalTime openTime, LocalTime closeTime){
+    public void updateStore(
+            String storeName, String address,
+            String phone, StoreCategory category,
+            Integer minPrice, LocalTime openTime,
+            LocalTime closeTime
+    ){
         this.storeName = storeName;
         this.address = address;
         this.phone = phone;
@@ -67,6 +71,7 @@ public class Store extends BaseEntity {
         this.openTime = openTime;
         this.closeTime = closeTime;
     }
+
     public void deleteStore() {
         this.closedFlag = false;
         this.deleteAt = LocalDateTime.now();

--- a/src/main/java/com/example/outsourcingproject/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/outsourcingproject/domain/store/repository/StoreRepository.java
@@ -4,12 +4,8 @@ import com.example.outsourcingproject.common.exception.BaseException;
 import com.example.outsourcingproject.common.exception.ErrorCode;
 import com.example.outsourcingproject.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Repository;
-import org.springframework.web.server.ResponseStatusException;
-import com.example.outsourcingproject.domain.store.entity.Store;
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,19 +21,30 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
         return findById(id).orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND, null));
     }
 
-    List<Store> findByUser_Id(Long userId);
+    List<Store> findByUser_Id(Long userId); // 삭제 혹은 영업 종료한 가게 인지 삭제된 유저인지
 
     boolean existsByStoreName(String storeName);
 
     @Query("SELECT COUNT(s) FROM Store s WHERE s.user.id = :userId AND s.deleteAt IS NULL")
     int countByUserId(@Param("userId") Long userId);
 
+    // 오너 유저용 매장 조회
+    @Query("SELECT s FROM Store s WHERE s.id = :storeId AND s.user.id = :userId AND s.deleteAt IS NULL")
+    Optional<Store> findByIdAndUserId(@Param("storeId") Long storeId, @Param("userId") Long userId);
+
+    @Query("SELECT s FROM Store s WHERE s.user.id= :userId AND s.deleteAt IS NULL")
+    List<Store> findAllByUserId(@Param("userId") Long userId);
+
+    @EntityGraph(attributePaths = "user")
+    Optional<Store> getStoreById(Long storeId);
+
+
+    // 일반 유저용 매장 조회
     @Query("SELECT s FROM Store s WHERE s.closedFlag = true AND s.deleteAt IS NULL")
     @EntityGraph(attributePaths = "user")
     List<Store> findAllOpenStores();
 
-
-    @Query("SELECT s FROM Store s WHERE s.id = :storeId AND s.deleteAt IS NULL")
+    @Query("SELECT s FROM Store s WHERE s.id = :storeId AND s.closedFlag = true AND s.deleteAt IS NULL")
     @EntityGraph(attributePaths = "user")
-    Optional<Store> getStoreById(Long storeId);
+    Optional<Store> getOpenStoreById(Long storeId);
 }

--- a/src/main/java/com/example/outsourcingproject/domain/store/service/StoreOwnerService.java
+++ b/src/main/java/com/example/outsourcingproject/domain/store/service/StoreOwnerService.java
@@ -3,6 +3,8 @@ package com.example.outsourcingproject.domain.store.service;
 import com.example.outsourcingproject.common.encoder.PasswordEncoder;
 import com.example.outsourcingproject.common.exception.BaseException;
 import com.example.outsourcingproject.common.exception.ErrorCode;
+import com.example.outsourcingproject.domain.menu.entity.Menu;
+import com.example.outsourcingproject.domain.menu.repository.MenuRepository;
 import com.example.outsourcingproject.domain.store.dto.request.StoreCreateRequestDto;
 import com.example.outsourcingproject.domain.store.dto.request.StoreDeleteRequestDto;
 import com.example.outsourcingproject.domain.store.dto.request.StoreUpdateRequestDto;
@@ -13,12 +15,10 @@ import com.example.outsourcingproject.domain.store.repository.StoreRepository;
 import com.example.outsourcingproject.domain.user.entity.User;
 import com.example.outsourcingproject.domain.user.entity.UserRole;
 import com.example.outsourcingproject.domain.user.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,9 +27,10 @@ import static com.example.outsourcingproject.common.exception.ErrorCode.USER_NOT
 
 @Service
 @RequiredArgsConstructor
-public class StoreService {
+public class StoreOwnerService {
     private final StoreRepository storeRepository;
     private final UserRepository userRepository;
+    private final MenuRepository menuRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -69,9 +70,9 @@ public class StoreService {
     }
 
     @Transactional(readOnly = true)
-    public List<StoreResponseDto> getAllStores() {
+    public List<StoreResponseDto> getAllStores(Long authUserId) {
         // closedFlag가 true인 경우만 조회
-        List<Store> stores = storeRepository.findAllOpenStores();
+        List<Store> stores = storeRepository.findAllByUserId(authUserId);
         return stores.stream()
                 .map(StoreResponseDto::fromEntity)
                 .collect(Collectors.toList());
@@ -79,23 +80,14 @@ public class StoreService {
 
     @Transactional(readOnly = true)
     public StoreResponseDto getStoreById(Long storeId, Long authUserId) {
-        userRepository.findById(authUserId)
-                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, null));
+//        userRepository.findById(authUserId)
+//                .orElseThrow(() -> new BaseException(ErrorCode.USER_NOT_FOUND, null));
 
-        Store store = storeRepository.getStoreById(storeId)
+        Store store = storeRepository.findByIdAndUserId(storeId, authUserId)
                 .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND, null));
-
-        // 폐업한 가게(closedFlag = false)는 점주만 조회 가능
-        if (!store.isClosedFlag()) {
-
-            if (!store.getUser().getId().equals(authUserId)) {
-                throw new BaseException(ErrorCode.UNAUTHORIZED_STORE_ACCESS, null);
-            }
-        }
-
+        List<Menu> menus = menuRepository.findAllByStoreId(storeId);
         return StoreResponseDto.fromEntity(store);
     }
-
 
     @Transactional
     public StoreResponseDto updateStore(Long authUserId, Long storeId, StoreUpdateRequestDto dto){
@@ -127,13 +119,13 @@ public class StoreService {
 
         // DTO에서 null이 아닌 값만 기존 필드 값으로 대체
         store.updateStore(
-                dto.getStoreName() != null ? dto.getStoreName() : store.getStoreName(),
-                dto.getAddress() != null ? dto.getAddress() : store.getAddress(),
-                dto.getPhone() != null ? dto.getPhone() : store.getPhone(),
-                dto.getCategory() != null ? dto.getCategory() : store.getCategory(),
-                dto.getMinPrice() != null ? dto.getMinPrice() : store.getMinPrice(),
-                dto.getOpenTime() != null ? dto.getOpenTime() : store.getOpenTime(),
-                dto.getCloseTime() != null ? dto.getCloseTime() : store.getCloseTime()
+                dto.getStoreName(),
+                dto.getAddress(),
+                dto.getPhone(),
+                dto.getCategory(),
+                dto.getMinPrice(),
+                dto.getOpenTime(),
+                dto.getCloseTime()
         );
 
         return StoreResponseDto.fromEntity(store);
@@ -172,12 +164,16 @@ public class StoreService {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND, null));
 
+        if(user.getUserRole() != UserRole.OWNER){
+            throw new BaseException(ErrorCode.INVALID_USER_ROLE, null);
+        }
+
         if (!store.getUser().getId().equals(authUserId)) {
             throw new BaseException(ErrorCode.UNAUTHORIZED_STORE_ACCESS, null);
         }
 
-        if(user.getUserRole() != UserRole.OWNER){
-            throw new BaseException(ErrorCode.INVALID_USER_ROLE, null);
+        if (store.getDeleteAt() != null) {
+            throw new BaseException(ErrorCode.CANNOT_MODIFY_DELETED_STORE, null);
         }
 
         store.toggleStoreStatus();

--- a/src/main/java/com/example/outsourcingproject/domain/store/service/StoreUserService.java
+++ b/src/main/java/com/example/outsourcingproject/domain/store/service/StoreUserService.java
@@ -1,0 +1,32 @@
+package com.example.outsourcingproject.domain.store.service;
+
+import com.example.outsourcingproject.common.exception.BaseException;
+import com.example.outsourcingproject.common.exception.ErrorCode;
+import com.example.outsourcingproject.domain.store.dto.response.StoreResponseDto;
+import com.example.outsourcingproject.domain.store.entity.Store;
+import com.example.outsourcingproject.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StoreUserService {
+
+    private final StoreRepository storeRepository;
+    public List<StoreResponseDto> getAllStores() {
+        List<Store> stores = storeRepository.findAllOpenStores();
+        return stores.stream()
+                .map(StoreResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public StoreResponseDto getStoreById(Long storeId) {
+        Store store = storeRepository.getOpenStoreById(storeId)
+                .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND, null));
+
+        return StoreResponseDto.fromEntity(store);
+    }
+}


### PR DESCRIPTION
## 📌 What is this PR ?

일반 유저는 가게를 조회할 때, 영업 중인지 폐업했는지 조건이 필요했고,
오너 유저는 본인의 가게, 폐업 중인 가게는 조회를 하지 못하는 조건이 필요했습니다.
이에 따라서 조회하는 url을 각각 컨트롤러, 서비스로 분리하였고, 레포지토리에 메서드가 추가되었습니다.

<br/>

## 🔎 Additions / Changes

## Additions
레포지토리에 유저용 가게 조회 메서드가 추가 되었습니다.
List<Store> findAllOpenStores();
Optional<Store> getOpenStoreById(Long storeId);
레포지토리에 오너용 가게 조회 메서드가 수정 되었습니다.
List<Store> findAllByUserId(@Param("userId") Long userId);
Optional<Store> findByIdAndUserId(@Param("storeId") Long storeId, @Param("userId") Long userId);

## Changes
기존 StoreController를 StoreOwnerController, StoreUserController로 분리하였습니다.
기존 StoreService를 StoreOwnerService, StoreUserService로 분리하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 폐업한 가게의 수정 시도에 대해 명확한 오류 메시지가 제공됩니다.
	- 소유자 전용과 사용자 전용 상점 관리 API 엔드포인트가 분리되어 각 사용자 유형에 맞는 기능을 제공합니다.
	- 사용자 인증 기반 상점 조회 및 상세 정보 확인 기능이 도입되었습니다.
- **리팩토링**
	- 상점 정보 입력 시 필수 항목(가게 이름, 주소, 전화번호, 카테고리, 최소 주문 금액, 오픈/마감시간)에 대한 유효성 검사가 강화되었습니다.
	- 상점 관련 서비스 및 업데이트 로직이 개선되어 효율성과 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->